### PR TITLE
update UnitTest.py so it runs; remove redundant TICC init args

### DIFF
--- a/TICC_solver.py
+++ b/TICC_solver.py
@@ -14,33 +14,21 @@ from src.admm_solver import ADMMSolver
 
 
 class TICC:
-    window_size = 10
-    number_of_clusters = 5
-    lambda_parameter = 11e-2
-    switch_penalty = 400
-    maxIters = 1000
-    threshold = 2e-5
-    write_out_file = False
-    prefix_string = ''
-    num_proc = 1
-    compute_BIC = False
-    num_blocks = None
-    cluster_reassignment = 20  # number of points to reassign to a 0 cluster
-
     def __init__(self, window_size=10, number_of_clusters=5, lambda_parameter=11e-2,
                  beta=400, maxIters=1000, threshold=2e-5, write_out_file=False,
-                 prefix_string="", num_proc=1, compute_BIC=False):
+                 prefix_string="", num_proc=1, compute_BIC=False, cluster_reassignment=20):
         """
-                Parameters:
-                    - window_size: size of the sliding window
-                    - number_of_clusters: number of clusters
-                    - lambda_parameter: sparsity parameter
-                    - switch_penalty: temporal consistency parameter
-                    - maxIters: number of iterations
-                    - threshold: convergence threshold
-                    - write_out_file: (bool) if true, prefix_string is output file dir
-                    - prefix_string: output directory if necessary
-                """
+        Parameters:
+            - window_size: size of the sliding window
+            - number_of_clusters: number of clusters
+            - lambda_parameter: sparsity parameter
+            - switch_penalty: temporal consistency parameter
+            - maxIters: number of iterations
+            - threshold: convergence threshold
+            - write_out_file: (bool) if true, prefix_string is output file dir
+            - prefix_string: output directory if necessary
+            - cluster_reassignment: number of points to reassign to a 0 cluster
+        """
         self.window_size = window_size
         self.number_of_clusters = number_of_clusters
         self.lambda_parameter = lambda_parameter
@@ -51,7 +39,7 @@ class TICC:
         self.prefix_string = prefix_string
         self.num_proc = num_proc
         self.compute_BIC = compute_BIC
-
+        self.cluster_reassignment = cluster_reassignment
         self.num_blocks = self.window_size + 1
         pd.set_option('display.max_columns', 500)
         np.set_printoptions(formatter={'float': lambda x: "{0:0.4f}".format(x)})

--- a/UnitTest.py
+++ b/UnitTest.py
@@ -1,5 +1,5 @@
 import unittest
-import TICC_solver as TICC
+from TICC_solver import TICC
 import numpy as np
 import sys
 
@@ -10,7 +10,9 @@ class TestStringMethods(unittest.TestCase):
 
     def test_example(self):
         fname = "example_data.txt"
-        (cluster_assignment, cluster_MRFs) = TICC.solve(window_size = 1,number_of_clusters = 8, lambda_parameter = 11e-2, beta = 600, maxIters = 100, threshold = 2e-5, write_out_file = False, input_file = fname, prefix_string = "output_folder/", num_proc=1)
+        ticc = TICC(window_size = 1,number_of_clusters = 8, lambda_parameter = 11e-2, beta = 600, maxIters = 100,
+                    threshold = 2e-5, write_out_file = False, prefix_string = "output_folder/", num_proc=1)
+        (cluster_assignment, cluster_MRFs) = ticc.fit(input_file=fname)
         assign = np.loadtxt("UnitTest_Data/Results.txt")
         val = abs(assign - cluster_assignment)
         self.assertEqual(sum(val), 0)
@@ -21,13 +23,14 @@ class TestStringMethods(unittest.TestCase):
                 np.testing.assert_array_almost_equal(mrf, cluster_MRFs[i], decimal=3)
             except AssertionError:
                 #Test failed
-                self.assertTrue(1==0)             
+                self.assertTrue(1==0)
 
 
     def test_multiExample(self):
         fname = "example_data.txt"
-        (cluster_assignment, cluster_MRFs) = TICC.solve(window_size = 5,number_of_clusters = 5, lambda_parameter = 11e-2, beta = 600, maxIters = 100, threshold = 2e-5, write_out_file = False, input_file = fname, prefix_string = "output_folder/", num_proc=1)
-        
+        ticc = TICC(window_size = 5,number_of_clusters = 5, lambda_parameter = 11e-2, beta = 600, maxIters = 100,
+                    threshold = 2e-5, write_out_file = False, prefix_string = "output_folder/", num_proc=1)
+        (cluster_assignment, cluster_MRFs) = ticc.fit(input_file=fname)
         assign = np.loadtxt("UnitTest_Data/multiResults.txt")
         val = abs(assign - cluster_assignment)
         self.assertEqual(sum(val), 0)


### PR DESCRIPTION
Just a couple minor changes, since UnitTest wouldn't run as is when I pulled it.