### PR TITLE
modify file load function

### DIFF
--- a/TICC_solver.py
+++ b/TICC_solver.py
@@ -45,17 +45,18 @@ class TICC:
         np.set_printoptions(formatter={'float': lambda x: "{0:0.4f}".format(x)})
         np.random.seed(102)
 
-    def fit(self, input_file):
+    def fit(self, input_file, delimiter=","):
         """
         Main method for TICC solver.
         Parameters:
             - input_file: location of the data file
+            - delimiter: delimiter of the data in the input file
         """
         assert self.maxIters > 0  # must have at least one iteration
         self.log_parameters()
 
         # Get data into proper format
-        times_series_arr, time_series_rows_size, time_series_col_size = self.load_data(input_file)
+        times_series_arr, time_series_rows_size, time_series_col_size = self.load_data(input_file, delimiter)
 
         ############
         # The basic folder to be created
@@ -358,8 +359,8 @@ class TICC:
 
         return str_NULL
 
-    def load_data(self, input_file):
-        Data = np.loadtxt(input_file, delimiter=",")
+    def load_data(self, input_file, delimiter):
+        Data = np.loadtxt(input_file, delimiter=delimiter)
         (m, n) = Data.shape  # m: num of observations, n: size of observation vector
         print("completed getting the data")
         return Data, m, n


### PR DESCRIPTION
# What problem does this PR solve?
- fix the error at fit because the input file delimiter is not the same as the delimiter used in the TICC class.

# What is changed and how it works?
- modify the fit function & load_data function
- users can split the symbols of the data in their own files, which is more flexible

# Check List
- run example.py