### PR TITLE
TICC fails with clusters with only one observation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /**/*.pyc
 
+
+.idea/
+
+Results.txt

--- a/TICC_solver.py
+++ b/TICC_solver.py
@@ -16,7 +16,7 @@ from src.admm_solver import ADMMSolver
 class TICC:
     def __init__(self, window_size=10, number_of_clusters=5, lambda_parameter=11e-2,
                  beta=400, maxIters=1000, threshold=2e-5, write_out_file=False,
-                 prefix_string="", num_proc=1, compute_BIC=False, cluster_reassignment=20):
+                 prefix_string="", num_proc=1, compute_BIC=False, cluster_reassignment=20, biased=False):
         """
         Parameters:
             - window_size: size of the sliding window
@@ -28,6 +28,7 @@ class TICC:
             - write_out_file: (bool) if true, prefix_string is output file dir
             - prefix_string: output directory if necessary
             - cluster_reassignment: number of points to reassign to a 0 cluster
+            - biased: Using the biased covariance or the unbiased
         """
         self.window_size = window_size
         self.number_of_clusters = number_of_clusters
@@ -41,6 +42,7 @@ class TICC:
         self.compute_BIC = compute_BIC
         self.cluster_reassignment = cluster_reassignment
         self.num_blocks = self.window_size + 1
+        self.biased = biased
         pd.set_option('display.max_columns', 500)
         np.set_printoptions(formatter={'float': lambda x: "{0:0.4f}".format(x)})
         np.random.seed(102)
@@ -328,7 +330,7 @@ class TICC:
                 ##Fit a model - OPTIMIZATION
                 probSize = self.window_size * size_blocks
                 lamb = np.zeros((probSize, probSize)) + self.lambda_parameter
-                S = np.cov(np.transpose(D_train))
+                S = np.cov(np.transpose(D_train), bias=self.biased)
                 empirical_covariances[cluster] = S
 
                 rho = 1

--- a/TICC_solver.py
+++ b/TICC_solver.py
@@ -28,7 +28,7 @@ class TICC:
             - write_out_file: (bool) if true, prefix_string is output file dir
             - prefix_string: output directory if necessary
             - cluster_reassignment: number of points to reassign to a 0 cluster
-            - biased: Using the biased covariance or the unbiased
+            - biased: Using the biased or the unbiased covariance
         """
         self.window_size = window_size
         self.number_of_clusters = number_of_clusters

--- a/UnitTest.py
+++ b/UnitTest.py
@@ -64,6 +64,34 @@ class TestStringMethods(unittest.TestCase):
                 #Test failed
                 self.assertTrue(1==0)
 
+    def test_biased_vs_unbiased(self):
+        fname = "example_data.txt"
+        unbiased_ticc = TICC(window_size=1, number_of_clusters=8, lambda_parameter=11e-2, beta=600, maxIters=100,
+                             threshold=2e-5,
+                             write_out_file=False, prefix_string="output_folder/", num_proc=1)
+        (unbiased_cluster_assignment, unbiased_cluster_MRFs) = unbiased_ticc.fit(input_file=fname)
+
+        biased_ticc = TICC(window_size=1, number_of_clusters=8, lambda_parameter=11e-2, beta=600, maxIters=100,
+                           threshold=2e-5,
+                           write_out_file=False, prefix_string="output_folder/", num_proc=1, biased=True)
+        (biased_cluster_assignment, biased_cluster_MRFs) = biased_ticc.fit(input_file=fname)
+
+        print(biased_cluster_assignment)
+        print(unbiased_cluster_assignment)
+
+        np.testing.assert_array_equal(np.array(biased_cluster_assignment), np.array(unbiased_cluster_assignment), "Biased assignment is not equel to unbiased assignment!")
+
+    def test_failed_unbiased(self):
+        with self.assertRaises(Exception) as context:
+            # TICC will fail in Iteration 2, because cluster 9 has only one observation.
+            fname = "example_data.txt"
+            ticc = TICC(window_size=1, number_of_clusters=50, lambda_parameter=11e-2, beta=600, maxIters=100,
+                        threshold=2e-5,
+                        write_out_file=False, prefix_string="output_folder/", num_proc=1)
+            (cluster_assignment, cluster_MRFs) = ticc.fit(input_file=fname)
+
+        self.assertTrue('This is broken {}'.format(context.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/UnitTest.py
+++ b/UnitTest.py
@@ -76,9 +76,6 @@ class TestStringMethods(unittest.TestCase):
                            write_out_file=False, prefix_string="output_folder/", num_proc=1, biased=True)
         (biased_cluster_assignment, biased_cluster_MRFs) = biased_ticc.fit(input_file=fname)
 
-        print(biased_cluster_assignment)
-        print(unbiased_cluster_assignment)
-
         np.testing.assert_array_equal(np.array(biased_cluster_assignment), np.array(unbiased_cluster_assignment), "Biased assignment is not equel to unbiased assignment!")
 
     def test_failed_unbiased(self):


### PR DESCRIPTION
Hi David

I used your algorithm for anomaly detection on airplane data. This was in the context of my master thesis. I found the next potential problem. 

If the number of clusters is too high, TICC might fail because it contains clusters with only one observation. It calculates the covariance matrix of the clusters using the unbiased covariance formula (with N-1 in the denominator), where N is the amount of observations. 

In this case, it will divide by 0, which results in NaN and causes a failure of the algorithm. Clusters with only one observation are not typical, but might be interesting for anomaly detection. TICC is based on the EM-algorithm and will thus iterate, it is thus also possible that it has temporary clusters of size one. Hence, It would be handy if TICC could work with clusters of size one.

Thus, I added an option to choose between the unbiased and the biased (biased divides by N) covariance. 
I also added some tests, which illustrate the failure and illustrate that both result in the same cluster assignment. I also had a closer look to the biased and the unbiased covariance matrices. The differences between them are mostly very small. In one of my experiments, the differences are of magnitude 10e-2 or smaller.

Another option would be to only use the biased covariance if there is only one observation, but I leave this up to u.

Kind regards
Jordy Heusdens


